### PR TITLE
Style change: capitalize Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About Me
 
 - 🔭 I’m currently working on: coursework for my masters in public health including longitudinal data analysis, HIV/AIDS epidemiology, & applied probability; and [updating the R Healthy Eating Index script](https://github.com/matthew-hoctor/hei2)
-- 🌱 I’m currently learning: R, epidemiology, biostatistics, python
+- 🌱 I’m currently learning: R, epidemiology, biostatistics, Python
 - 👯 I’m looking to collaborate on: projects related to the epidemiology of chronic disease
 - 📫 How to reach me: hoctor@pdx.edu
 - 😄 Pronouns: he/him/his


### PR DESCRIPTION
Nice profile Matt! Consider capitalizing the work "Python." This is the style that Wikipedia uses in [its article about Python](https://en.wikipedia.org/wiki/Python_(programming_language)).